### PR TITLE
Fixed a small warning

### DIFF
--- a/src/internet/model/mptcp-socket-base.cc
+++ b/src/internet/model/mptcp-socket-base.cc
@@ -318,7 +318,8 @@ MpTcpSocketBase::OnSubflowClosed(Ptr<MpTcpSubflow> subflow, bool reset)
   {
     NS_FATAL_ERROR("Case not handled yet.");
   }
-  SubflowList::iterator it = std::remove(m_subflows[Closing].begin(), m_subflows[Closing].end(), subflow);
+  SubflowList::iterator it;
+  it = std::remove(m_subflows[Closing].begin(), m_subflows[Closing].end(), subflow);
 }
 
 void


### PR DESCRIPTION
The iterator was being created in a way that raises a warning, and therefore, by default, an error.
